### PR TITLE
Update GitHub-Description.md

### DIFF
--- a/Operations/Outreach/Branding-Items/GitHub-Description.md
+++ b/Operations/Outreach/Branding-Items/GitHub-Description.md
@@ -2,4 +2,4 @@
 usage-locations:
   - GitHub About section for SKR-Core
 ---
-Core Repository for UCF Solar Knights Racing 
+Solar Knights Racing Core Repository

--- a/Operations/Outreach/Branding-Items/GitHub-Description.md
+++ b/Operations/Outreach/Branding-Items/GitHub-Description.md
@@ -2,5 +2,4 @@
 usage-locations:
   - GitHub About section for SKR-Core
 ---
-UCF Solar Knights Racing
-Monolithic repository
+Mono Repo for UCF Solar Knights Racing

--- a/Operations/Outreach/Branding-Items/GitHub-Description.md
+++ b/Operations/Outreach/Branding-Items/GitHub-Description.md
@@ -2,4 +2,4 @@
 usage-locations:
   - GitHub About section for SKR-Core
 ---
-Mono Repo for UCF Solar Knights Racing
+Core Repository for UCF Solar Knights Racing 


### PR DESCRIPTION
Made the repository description more readable. I am open to, and encouraging, edits.

When sharing the **repository link** (https://github.com/SolarKnightsRacing/SKR-Core), the caption is displayed in the format:
`GitHub - SolarKnightsRacing/SKR-Core: {Description}`
